### PR TITLE
fix(emoticon): 修复获取表情错误时的空指针闪退问题

### DIFF
--- a/app/src/main/java/io/github/acedroidx/danmaku/data/EmoticonRepository.kt
+++ b/app/src/main/java/io/github/acedroidx/danmaku/data/EmoticonRepository.kt
@@ -9,7 +9,7 @@ import javax.inject.Singleton
 @Singleton
 class EmoticonRepository @Inject constructor() {
     private val _emoticonGroups :MutableStateFlow<List<EmoticonGroup>> = MutableStateFlow(listOf())
-    val emoticonGroups : StateFlow<List<EmoticonGroup>> = _emoticonGroups
+    val emoticonGroups : StateFlow<List<EmoticonGroup>?> = _emoticonGroups
 
     private val _isPrepare : MutableStateFlow<Boolean> = MutableStateFlow(false)
     val isPrepare : StateFlow<Boolean> = _isPrepare

--- a/app/src/main/java/io/github/acedroidx/danmaku/model/EmoticonResult.kt
+++ b/app/src/main/java/io/github/acedroidx/danmaku/model/EmoticonResult.kt
@@ -1,0 +1,7 @@
+package io.github.acedroidx.danmaku.model
+
+data class EmoticonResult (
+    val code: Int,
+    val message: String?,
+    val data : EmoticonResultData?
+)

--- a/app/src/main/java/io/github/acedroidx/danmaku/model/EmoticonResultData.kt
+++ b/app/src/main/java/io/github/acedroidx/danmaku/model/EmoticonResultData.kt
@@ -1,0 +1,5 @@
+package io.github.acedroidx.danmaku.model
+
+data class EmoticonResultData(
+    val data: List<EmoticonGroup>?
+)

--- a/app/src/main/java/io/github/acedroidx/danmaku/ui/widgets/EditDanmakuProfile.kt
+++ b/app/src/main/java/io/github/acedroidx/danmaku/ui/widgets/EditDanmakuProfile.kt
@@ -224,7 +224,7 @@ object EditDanmakuProfile {
                 sheetState = sheetState
             ) {
                 if (isPrepare) {
-                    EmoticonPickerRaw(profile, emoticonGroups, onChange)
+                    emoticonGroups?.let { EmoticonPickerRaw(profile, it, onChange) }
                 }
             }
         }


### PR DESCRIPTION
- 在 EditDanmakuProfile 中添加空值检查以防止空指针异常
- 在 EmoticonRepository 中将 emoticonGroups 的类型改为可空类型
- 新增 EmoticonResult 和 EmoticonResultData模型类用于简化解析 API 响应